### PR TITLE
Fix file upload through resource_create API

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -362,6 +362,7 @@ class ResourceCloudStorage(CloudStorage):
                     # over lines, not over chunks and it will really
                     # slow down the process for files that consist of
                     # millions of short linew
+                    self.file_upload.seek(0, os.SEEK_SET)
                     if isinstance(file_upload, tempfile.SpooledTemporaryFile):
                         file_upload.rollover()
                         try:


### PR DESCRIPTION
## Description
We should set the position to the beginning of the file before upload.
Otherwise data could be missing from the file.