### PR TITLE
CKAN 2.7 - Use TLS v1.2 by default

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -14,10 +14,13 @@ import ckan.plugins as p
 
 from libcloud.storage.types import Provider, ObjectDoesNotExistError
 from libcloud.storage.providers import get_driver
+import ssl
+import libcloud.security
 
 
 class CloudStorage(object):
     def __init__(self):
+        libcloud.security.SSL_VERSION = ssl.PROTOCOL_TLSv1_2
         self.driver = get_driver(
             getattr(
                 Provider,


### PR DESCRIPTION
## Description
For compatibility reasons Libcloud uses TLS v1.0 by default to support older Python versions.
This PR updates Libcloud to use TLS v1.2 by default.

https://libcloud.readthedocs.io/en/stable/other/ssl-certificate-validation.html#changing-used-ssl-tls-version