### PR TITLE
CKAN 2.9 - Use TLS v1.2 by default

### DIFF
--- a/ckanext/cloudstorage/storage.py
+++ b/ckanext/cloudstorage/storage.py
@@ -19,6 +19,9 @@ from ckan.lib import munge
 from libcloud.storage.providers import get_driver
 from libcloud.storage.types import ObjectDoesNotExistError, Provider
 from werkzeug.datastructures import FileStorage as FlaskFileStorage
+import ssl
+import libcloud.security
+
 
 config = p.toolkit.config
 
@@ -65,6 +68,7 @@ def _md5sum(fobj):
 
 class CloudStorage(object):
     def __init__(self):
+        libcloud.security.SSL_VERSION = ssl.PROTOCOL_TLSv1_2
         self.driver = get_driver(getattr(Provider, self.driver_name))(
             **self.driver_options
         )


### PR DESCRIPTION
## Description
For compatibility reasons Libcloud uses TLS v1.0 by default to support older Python versions.
This PR updates Libcloud to use TLS v1.2 by default.

https://libcloud.readthedocs.io/en/stable/other/ssl-certificate-validation.html#changing-used-ssl-tls-version