### PR TITLE
Fix resource upload with same name

### DIFF
--- a/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
+++ b/ckanext/cloudstorage/fanstatic/scripts/cloudstorage-multipart-upload.js
@@ -424,7 +424,7 @@ ckan.module("cloudstorage-multipart-upload", function($, _) {
             // self._form.remove();
             if (self._clickedBtn == "again") {
               this._redirect_url = self.sandbox.url(
-                "/dataset/new_resource/" + self._packageId
+                "/dataset/" + self._packageId + "/resource/new"
               );
             } else {
               this._redirect_url = self.sandbox.url(

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -238,11 +238,15 @@ def finish_multipart(context, data_dict):
     ]
     uploader = get_resource_uploader({"id": upload.resource_id})
 
-    try:
-        obj = uploader.container.get_object(upload.name)
-        obj.delete()
-    except Exception:
-        pass
+    ## Disable the block below, because it causes 404 error when user
+    ## uploads a file with the same name as previous file.
+    # TODO: investigate possible side effects
+    # try:
+    #     obj = uploader.container.get_object(upload.name)
+    #     obj.delete()
+    # except Exception:
+    #     pass
+
     uploader.driver._commit_multipart(
         container=uploader.container,
         object_name=upload.name,

--- a/ckanext/cloudstorage/logic/action/multipart.py
+++ b/ckanext/cloudstorage/logic/action/multipart.py
@@ -236,8 +236,8 @@ def finish_multipart(context, data_dict):
     ]
     uploader = get_resource_uploader({"id": upload.resource_id})
 
-    ## Disable the block below, because it causes 404 error when user
-    ## uploads a file with the same name as previous file.
+    # Disable the block below, because it causes 404 error when user
+    # uploads a file with the same name as previous file.
     # TODO: investigate possible side effects
     # try:
     #     obj = uploader.container.get_object(upload.name)

--- a/ckanext/cloudstorage/tests/logic/action/test_multipart.py
+++ b/ckanext/cloudstorage/tests/logic/action/test_multipart.py
@@ -117,7 +117,6 @@ class TestMultipartUpload(object):
         assert url
         assert requests.get(url).content == fp.getvalue()
 
-
         fp = BytesIO(b"a" * 10)
         fp.seek(0)
         res = _upload(res, filename, 10, [fp])


### PR DESCRIPTION
## Description
This PR fixes a 404 error when a user uploads a file with the same name as previous file.